### PR TITLE
make strong `SKPSMTPMessageDelegate`'s instance

### DIFF
--- a/SMTPLibrary/SKPSMTPMessage.h
+++ b/SMTPLibrary/SKPSMTPMessage.h
@@ -134,7 +134,7 @@ extern NSString *kSKPSMTPPartContentTransferEncodingKey;
 
 @property(nonatomic, assign) NSTimeInterval connectTimeout;
 
-@property(nonatomic, assign) id <SKPSMTPMessageDelegate> delegate;
+@property(nonatomic, strong) id <SKPSMTPMessageDelegate> delegate;
 
 - (BOOL)send;
 


### PR DESCRIPTION
I always got an error while using the latest version of `skpsmtpmessage`. the error message is `[SKPSMTPMessage setWatchdogTimer:]: message sent to de allocated instance`. The error is showing when skpsmtp try to invoke implemented delegate.

I try to make `SKPSMTPMessageDelegate`'s instance in `SKPSMTPMessage.h` to strong and solve this problem.
