### PR TITLE
Add UTF-8 charset info

### DIFF
--- a/Demo/Classes/SMTPSenderAppDelegate.m
+++ b/Demo/Classes/SMTPSenderAppDelegate.m
@@ -114,7 +114,7 @@
     // testMsg.validateSSLChain = NO;
     testMsg.delegate = self;
     
-    NSDictionary *plainPart = [NSDictionary dictionaryWithObjectsAndKeys:@"text/plain",kSKPSMTPPartContentTypeKey,
+    NSDictionary *plainPart = [NSDictionary dictionaryWithObjectsAndKeys:@"text/plain; charset=UTF-8",kSKPSMTPPartContentTypeKey,
                                @"This is a tést messåge.",kSKPSMTPPartMessageKey,@"8bit",kSKPSMTPPartContentTransferEncodingKey,nil];
     
     NSString *vcfPath = [[NSBundle mainBundle] pathForResource:@"test" ofType:@"vcf"];


### PR DESCRIPTION
Add UTF-8 charset info to the text message
Otherwise the 8bit content transfer encoding is pretty useless with most email clients
