### PR TITLE
add friendly name to DATA headers, if provided

### DIFF
--- a/SMTPLibrary/SKPSMTPMessage.h
+++ b/SMTPLibrary/SKPSMTPMessage.h
@@ -83,7 +83,9 @@ extern NSString *kSKPSMTPPartContentTransferEncodingKey;
     
     NSString *subject;
     NSString *fromEmail;
+    NSString *fromFriendlyName;
     NSString *toEmail;
+    NSString *toFriendlyName;
 	NSString *ccEmail;
 	NSString *bccEmail;
     NSArray *parts;
@@ -127,7 +129,9 @@ extern NSString *kSKPSMTPPartContentTransferEncodingKey;
 
 @property(nonatomic, retain) NSString *subject;
 @property(nonatomic, retain) NSString *fromEmail;
+@property(nonatomic, retain) NSString *fromFriendlyName;
 @property(nonatomic, retain) NSString *toEmail;
+@property(nonatomic, retain) NSString *toFriendlyName;
 @property(nonatomic, retain) NSString *ccEmail;
 @property(nonatomic, retain) NSString *bccEmail;
 @property(nonatomic, retain) NSArray *parts;

--- a/SMTPLibrary/SKPSMTPMessage.m
+++ b/SMTPLibrary/SKPSMTPMessage.m
@@ -59,8 +59,8 @@ NSString *kSKPSMTPPartContentTransferEncodingKey = @"kSKPSMTPPartContentTransfer
 
 @implementation SKPSMTPMessage
 
-@synthesize login, pass, relayHost, relayPorts, subject, fromEmail, toEmail, parts, requiresAuth, inputString, wantsSecure, \
-            delegate, connectTimer, connectTimeout, watchdogTimer, validateSSLChain;
+@synthesize login, pass, relayHost, relayPorts, subject, fromEmail, fromFriendlyName, toEmail, toFriendlyName, parts, requiresAuth, \
+            inputString, wantsSecure, delegate, connectTimer, connectTimeout, watchdogTimer, validateSSLChain;
 @synthesize ccEmail;
 @synthesize bccEmail;
 
@@ -100,7 +100,9 @@ NSString *kSKPSMTPPartContentTransferEncodingKey = @"kSKPSMTPPartContentTransfer
     self.relayPorts = nil;
     self.subject = nil;
     self.fromEmail = nil;
+    self.fromFriendlyName = nil;
     self.toEmail = nil;
+    self.toFriendlyName = nil;
 	self.ccEmail = nil;
 	self.bccEmail = nil;
     self.parts = nil;
@@ -125,6 +127,7 @@ NSString *kSKPSMTPPartContentTransferEncodingKey = @"kSKPSMTPPartContentTransfer
     SKPSMTPMessage *smtpMessageCopy = [[[self class] allocWithZone:zone] init];
     smtpMessageCopy.delegate = self.delegate;
     smtpMessageCopy.fromEmail = self.fromEmail;
+    smtpMessageCopy.fromFriendlyName = self.fromFriendlyName;
     smtpMessageCopy.login = self.login;
     smtpMessageCopy.parts = [[self.parts copy] autorelease];
     smtpMessageCopy.pass = self.pass;
@@ -132,6 +135,7 @@ NSString *kSKPSMTPPartContentTransferEncodingKey = @"kSKPSMTPPartContentTransfer
     smtpMessageCopy.requiresAuth = self.requiresAuth;
     smtpMessageCopy.subject = self.subject;
     smtpMessageCopy.toEmail = self.toEmail;
+    smtpMessageCopy.toFriendlyName = self.toFriendlyName;
     smtpMessageCopy.wantsSecure = self.wantsSecure;
     smtpMessageCopy.validateSSLChain = self.validateSSLChain;
     smtpMessageCopy.ccEmail = self.ccEmail;
@@ -848,16 +852,28 @@ NSString *kSKPSMTPPartContentTransferEncodingKey = @"kSKPSMTPPartContentTransfer
     [dateFormatter release];
     [uuid release];
     
-    [message appendFormat:@"From:%@\r\n", fromEmail];
-	
+
+  if ((self.fromFriendlyName != nil) && (![self.fromFriendlyName isEqualToString:@""]))
+  {
+    [message appendFormat:@"From:\"%@\" <%@>\r\n", self.fromFriendlyName, self.fromEmail];
+  }	 
+  else {
+    [message appendFormat:@"From:%@\r\n", self.fromEmail];
+  }
     
 	if ((self.toEmail != nil) && (![self.toEmail isEqualToString:@""])) 
+  {
+    if ((self.toFriendlyName != nil) && (![self.toFriendlyName isEqualToString:@""]))
     {
-		[message appendFormat:@"To:%@\r\n", self.toEmail];		
+      [message appendFormat:@"To:\"%@\" <%@>\r\n", self.toFriendlyName, self.toEmail];
+    }
+    else {
+		  [message appendFormat:@"To:%@\r\n", self.toEmail];		
+    }
 	}
 
 	if ((self.ccEmail != nil) && (![self.ccEmail isEqualToString:@""])) 
-    {
+  {
 		[message appendFormat:@"Cc:%@\r\n", self.ccEmail];		
 	}
     


### PR DESCRIPTION
Adds ability to specify a "To/From" friendly name for an email's `To:` and `From:` DATA headers.
