### PR TITLE
Catch errors which aren't predefined

### DIFF
--- a/SMTPLibrary/SKPSMTPMessage.h
+++ b/SMTPLibrary/SKPSMTPMessage.h
@@ -62,6 +62,7 @@ extern NSString *kSKPSMTPPartContentTransferEncodingKey;
 #define kSKPSMTPErrorNonExistentDomain 1
 #define kSKPSMTPErrorInvalidUserPass 535
 #define kSKPSMTPErrorInvalidMessage 550
+#define kSKPSMTPErrorBadResponse -6 //all 4xx and 5xx response codes
 #define kSKPSMTPErrorNoRelay 530
 
 @class SKPSMTPMessage;

--- a/SMTPLibrary/SKPSMTPMessage.m
+++ b/SMTPLibrary/SKPSMTPMessage.m
@@ -811,6 +811,16 @@ NSString *kSKPSMTPPartContentTransferEncodingKey = @"kSKPSMTPPartContentTransfer
             break;
         }
     }
+    
+    if (!encounteredError && ([tmpLine hasPrefix:@"5"] || [tmpLine hasPrefix:@"4"])) {
+        NSString *format = NSLocalizedString(@"SMTP Error %@", @"server report unrecoverable error, user needs to change input");
+        NSString *message = [NSString stringWithFormat:format, tmpLine];
+        error = [NSError errorWithDomain:@"SKPSMTPMessageError"
+                                    code:kSKPSMTPErrorBadResponse
+                                userInfo:[NSDictionary dictionaryWithObjectsAndKeys:message,NSLocalizedDescriptionKey,nil]];
+        encounteredError = YES;
+    }
+    
     self.inputString = [[[inputString substringFromIndex:[scanner scanLocation]] mutableCopy] autorelease];
     
     if (messageSent)


### PR DESCRIPTION
If error isn't predefined, library will just reset watchdog and ignore response. This MR resolves that, passing response as human readable string